### PR TITLE
Bump version to 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.4.1
+## 1.4.2
 - Update dependencies
 - Fix #168: status bar was not working due to missed items when the extension namespace was changed.
 ## 1.4.0

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"license": "SEE LICENSE IN README.md",
 	"repository": "https://github.com/lhl2617/VSLilyPond",
 	"description": "Provides syntax and error highlighting, compilation on save, MIDI (input and playback) support for LilyPond in VSCode. ",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"preview": true,
 	"icon": "assets/icon.png",
 	"engines": {


### PR DESCRIPTION
Accidentally bumped to 1.4.2 and realised it is not possible to bump it back down to 1.4.1

This is an open issue: https://github.com/microsoft/vscode-vsce/issues/176

Bump it back up to 1.4.2 and republishing.