### PR TITLE
Use the MIDI status byte to determine keyDown

### DIFF
--- a/src/midi-in.ts
+++ b/src/midi-in.ts
@@ -174,13 +174,13 @@ export namespace MIDIIn {
   export const processNote =
     (
       MIDINoteNumber: number,
-      velocity: number,
+      keyDown: boolean,
       MIDIInputConfig: MIDIInputConfig
     ) =>
     (outputNoteFn: OutputNotesFnType) => {
       const { accidentals, relativeMode, chordMode } = MIDIInputConfig
 
-      if (velocity) {
+      if (keyDown) {
         // press down
 
         // if not chord mode, input the note that was still held
@@ -229,11 +229,16 @@ export namespace MIDIIn {
   // @ts-ignore
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   midiInMsgProcessor._receive = (msg: any) => {
+    const statusByte: number = msg[0]
     const MIDINoteNumber: number = msg[1]
-    if (MIDINoteNumber >= 12 && MIDINoteNumber <= 127) {
-      const velocity: number = msg[2] // 0 if lift
+    if (
+      [0x80, 0x90].includes(statusByte) &&
+      MIDINoteNumber >= 12 &&
+      MIDINoteNumber <= 127
+    ) {
+      const keyDown: boolean = statusByte === 0x90 // 0x90 indicates a keyDown event
       const MIDIInputConfig = getMIDIInputConfig()
-      processNote(MIDINoteNumber, velocity, MIDIInputConfig)(outputNotes)
+      processNote(MIDINoteNumber, keyDown, MIDIInputConfig)(outputNotes)
     } else {
       logger(`Received other MIDI message: ${msg}`, LogLevel.warning, true)
     }


### PR DESCRIPTION
The MIDI status byte is present in _every_ MIDI message, and indicates what the message actually is.
For a keyDown message, the byte is 0x90.

Many keyboards emit non-zero velocities on key up, and some are even variable based on the key return speed.

This commit changes both the MIDI message processor to _only_ look at messages with a keycode of 0x80 (keyUp) or 0x90 (keyDown), as well as ensuring the previous note range clamp is in effect. It fixes #341.

Furthermore, it fixes a class of issues where other control surface inputs were being captured as notes.

Here is what the output result looks like
![Screenshot 2021-09-03 at 20 47 03](https://user-images.githubusercontent.com/168193/132080184-d74dc6e0-70fd-4e99-bf13-28284e7fc43b.gif)
