### PR TITLE
Calculate the midi status type regardless of channel

### DIFF
--- a/src/midi-in.ts
+++ b/src/midi-in.ts
@@ -228,7 +228,7 @@ export namespace MIDIIn {
   // @ts-ignore
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   midiInMsgProcessor._receive = (msg: any) => {
-    const statusByte: number = msg[0]
+    const statusByte: number = msg[0] & 0xf0 // Get only the status byte type, ignore the channel
     const MIDINoteNumber: number = msg[1]
     if (
       [0x80, 0x90].includes(statusByte) &&


### PR DESCRIPTION
The previous implementation (71300a0) used 0x80 and 0x90 comparisons directly, which meant any midi device set to use a different channel would _not_ be seen by the plugin.

This is because a statusByte is defined as two sets of nibbles.

```
0x91 = 1001 0001
         9    1

    1001 0001
    Type Channel
```

The first nibble is what we care about, the type of message. The second is the channel, from 0 to 15.

So by using a simple bitmask, we can discard the channel information, and our checks continue to work