### PR TITLE
Handle keyUp status in running status mode

### DIFF
--- a/src/midi-in.ts
+++ b/src/midi-in.ts
@@ -230,12 +230,14 @@ export namespace MIDIIn {
   midiInMsgProcessor._receive = (msg: any) => {
     const statusByte: number = msg[0]
     const MIDINoteNumber: number = msg[1]
+    const velocity: number = msg[2]
     if (
       [0x80, 0x90].includes(statusByte) &&
       MIDINoteNumber >= 12 &&
       MIDINoteNumber <= 127
     ) {
-      const keyDown: boolean = statusByte === 0x90 // 0x90 indicates a keyDown event
+      // 0x90 indicates a keyDown event, 0 velocity check in the case of running status mode
+      const keyDown: boolean = statusByte === 0x90 && velocity > 0
       const MIDIInputConfig = getMIDIInputConfig()
       processNote(MIDINoteNumber, keyDown, MIDIInputConfig)(outputNotes)
     } else {


### PR DESCRIPTION
According to the MIDI spec, a keyDown with a velocity of 0 is equivalent to a keyUp status.
This is how the code previously worked, prior to 71300a0.

The MIDI spec section in question:
> Running Status is especially helpful when sending long strings of Note On/Off messages, where "Note On with Velocity of 0" is used for Note Off.

This commit reintroduces a check for that, while preserving the newer (as of 71300a0) status checks. That way, both keyUp AND keyDowns with 0 velocity are registered as keyUps


Interestingly enough, JZZ had issues with running status last year, but they have fixed them https://github.com/jazz-soft/JZZ/issues/26. Provided this holds true, we don't have to worry about maintaining current status for RS mode.