### PR TITLE
Fix MIDI timer increments minute counter at m:30 instead of m:00

### DIFF
--- a/src/midi-out.ts
+++ b/src/midi-out.ts
@@ -35,10 +35,8 @@ export namespace MIDIOut {
       throw new Error(`Time cannot be negative`)
     }
     const seconds = Math.round(ms / 1000)
-    const mm = Math.round(seconds / 60).toString()
-    const ss = Math.round(seconds % 60)
-      .toString()
-      .padStart(2, `0`)
+    const mm = Math.floor(seconds / 60).toString()
+    const ss = (seconds % 60).toString().padStart(2, `0`)
 
     return `${mm}:${ss}`
   }

--- a/src/test/suite/midi-out.test.ts
+++ b/src/test/suite/midi-out.test.ts
@@ -42,6 +42,16 @@ suite(`MIDIOut test suite`, () => {
         ms: 6023000,
         want: `100:23`,
       },
+      {
+        name: "rounding at 30 seconds",
+        ms: 90000,
+        want: `1:30`,
+      },
+      {
+        name: "rounding at 59 seconds",
+        ms: 119000,
+        want: `1:59`,
+      },
     ]
 
     const msToMMSSTestsException: {


### PR DESCRIPTION
Fixes #376

